### PR TITLE
using math.type in integer function

### DIFF
--- a/src/jnet/check.lua
+++ b/src/jnet/check.lua
@@ -1,5 +1,5 @@
 local function integer(thing)
-	return math.type(thing) == 'integer'
+	return math.type(thing) == "integer"
 end
 
 return {

--- a/src/jnet/check.lua
+++ b/src/jnet/check.lua
@@ -1,5 +1,5 @@
 local function integer(thing)
-	return type(thing) == "number" and math.floor(thing) == thing and math.abs(thing) < math.huge
+	return math.type(thing) == 'integer'
 end
 
 return {


### PR DESCRIPTION
Hi,
first, thanks for the module. I searched multiple times for a complete inet package and yours look really promising :)

I looked into `check.lua` and wanted to ask why not using `math.type` for the `integer()` function. According to the rockspec you support Lua >=5.3, so this is a much safer way to check it, because:
```
Lua 5.4.3  Copyright (C) 1994-2021 Lua.org, PUC-Rio
> function integer(thing) return type(thing) == "number" and math.floor(thing) == thing and math.abs(thing) < math.huge end
> integer(1.0)
true
```

But if you plan to support Lua down to 5.1 in the future, you can just close this one :)